### PR TITLE
Remove docker pulls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # php-base
 
 [![Test](https://github.com/violinist-dev/php-base/actions/workflows/test.yml/badge.svg)](https://github.com/violinist-dev/php-base/actions/workflows/test.yml)
-[![Docker Pulls](https://img.shields.io/docker/pulls/violinist/php-base)](https://hub.docker.com/r/violinist/php-base)
 
 Base image for all runners


### PR DESCRIPTION
Since we don't use docker hub anymore