### PR TITLE
Fix pecl not found when building PHP 8.6 alpha

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -31,6 +31,7 @@ jobs:
           - "8.3"
           - "8.4"
           - "8.5"
+          - "8.6"
     steps:
       -
         name: Checkout
@@ -54,6 +55,9 @@ jobs:
           PHP_VERSION: ${{ matrix.php-version }}
         run: |
           USE_VERSION=$PHP_VERSION
+          if [ "$PHP_VERSION" == "8.6" ]; then
+            USE_VERSION="8.6.0alpha1"
+          fi
           echo "name=$USE_VERSION" >> "$GITHUB_OUTPUT"
       - name: Build and push Docker image
         uses: docker/build-push-action@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - "8.3"
           - "8.4"
           - "8.5"
+          - "8.6"
     steps:
       - name: Dump matrix context
         env:
@@ -43,7 +44,7 @@ jobs:
         if: matrix.php-version == '8.6'
         run: docker build -t php-base --build-arg PHP_VERSION=$PHP_VERSION .
         env:
-          PHP_VERSION: '8.5.0RC1'
+          PHP_VERSION: '8.6.0alpha1'
 
       - name: Output modules
         run: docker run php-base php -m
@@ -61,5 +62,5 @@ jobs:
         run: composer --version
 
       - name: Check requirements
-        if: matrix.php-version != '8.5'
+        if: matrix.php-version != '8.5' && matrix.php-version != '8.6'
         run: docker run -w "/test" -v $(pwd):/test php-base composer install

--- a/php-install.sh
+++ b/php-install.sh
@@ -3,7 +3,14 @@ set -eu
 apk add --no-cache unixodbc-dev brotli-dev gmp-dev yaml-dev samba-dev libldap openldap-dev pcre-dev libxslt-dev imap-dev sudo git libpng libjpeg libpq libxml2 mysql-client openssh-client rsync patch bash imagemagick libzip-dev \
     imagemagick-libs unixodbc-dev rabbitmq-c rabbitmq-c-dev mpdecimal-dev gettext gettext-dev imagemagick-dev librdkafka-dev autoconf g++ make icu-dev libpng-dev libjpeg-turbo-dev postgresql-dev libxml2-dev bzip2-dev icu icu-dev libmemcached-dev linux-headers $PHPIZE_DEPS
 
-pecl channel-update pecl.php.net
+case $PHP_VERSION in
+  8.6*)
+    echo "Skipping pecl channel-update on PHP $PHP_VERSION (pecl is not available yet for this alpha release)"
+    ;;
+  *)
+    pecl channel-update pecl.php.net
+    ;;
+esac
 
 case $PHP_VERSION in
   7.3)
@@ -12,7 +19,7 @@ case $PHP_VERSION in
   7.4|8.0)
     echo "yes" | pecl install mongodb-1.20.1
     ;;
-  8.5*)
+  8.5*|8.6*)
     echo "Skipping mongo db driver for PHP $PHP_VERSION"
     ;;
   *)
@@ -21,7 +28,7 @@ case $PHP_VERSION in
 esac
 
 case $PHP_VERSION in
-  8.5*)
+  8.5*|8.6*)
     echo "Skipping mongodb for PHP $PHP_VERSION"
     ;;
   *)
@@ -42,7 +49,7 @@ case $PHP_VERSION in
     echo "" | pecl install swoole-6.1.8
     docker-php-ext-enable swoole
     ;;
-  8.5*)
+  8.5*|8.6*)
     echo "Skipping swoole for PHP $PHP_VERSION"
     ;;
   *)
@@ -58,6 +65,9 @@ case $PHP_VERSION in
   7.4|8.0|8.1)
     yes | pecl install ds-1.6.0
     ;;
+  8.6*)
+    echo "Skipping ds for PHP $PHP_VERSION"
+    ;;
   *)
     # If we really need it.
     php -m | grep -q '^ds$' || yes | pecl install ds
@@ -65,7 +75,7 @@ case $PHP_VERSION in
 esac
 
 case $PHP_VERSION in
-  8.5*)
+  8.5*|8.6*)
     php -m | grep -q '^igbinary$' || \
       (git clone --depth=1 https://github.com/igbinary/igbinary.git /usr/src/igbinary; \
         cd /usr/src/igbinary; \
@@ -80,7 +90,7 @@ case $PHP_VERSION in
 esac
 
 case $PHP_VERSION in
-  8.5*)
+  8.5*|8.6*)
       # Yknow if we really need it.
       php -m | grep -q '^mailparse$' || \
         (git clone --depth=1 https://github.com/php/pecl-mail-mailparse.git /usr/src/mailparse; \
@@ -95,7 +105,14 @@ case $PHP_VERSION in
     ;;
 esac
 
-yes | pecl install apcu rdkafka yaml uuid msgpack
+case $PHP_VERSION in
+  8.6*)
+    echo "Skipping apcu rdkafka yaml uuid msgpack for PHP $PHP_VERSION"
+    ;;
+  *)
+    yes | pecl install apcu rdkafka yaml uuid msgpack
+    ;;
+esac
 
 case $PHP_VERSION in
   7.3)
@@ -103,6 +120,9 @@ case $PHP_VERSION in
     ;;
   7.4|8.0|8.1)
     yes | pecl install decimal-1.5.3
+    ;;
+  8.6*)
+    echo "Skipping decimal for PHP $PHP_VERSION"
     ;;
   *)
     yes | pecl install decimal
@@ -113,13 +133,16 @@ case $PHP_VERSION in
   7.3)
     echo "" | pecl install amqp-1.11.0
     ;;
+  8.6*)
+    echo "Skipping amqp for PHP $PHP_VERSION"
+    ;;
   *)
     echo "" | pecl install amqp
     ;;
 esac
 
 case $PHP_VERSION in
-  8.5*)
+  8.5*|8.6*)
     echo "Skipping oauth extension for $PHP_VERSION"
     ;;
   *)
@@ -128,7 +151,7 @@ case $PHP_VERSION in
 esac
 
 case $PHP_VERSION in
-  8.5*)
+  8.5*|8.6*)
     echo "Skipping memcached for PHP $PHP_VERSION"
     ;;
   *)
@@ -150,7 +173,7 @@ case $PHP_VERSION in
   8.1|8.2)
     yes | pecl install sqlsrv-5.12.0 pdo_sqlsrv-5.12.0
     ;;
-  8.5*)
+  8.5*|8.6*)
     echo "Skipping sqlsrv on $PHP_VERSION"
     ;;
   *)
@@ -182,10 +205,17 @@ php -m | grep -q '^gettext$' || docker-php-ext-configure gettext
 php -m | grep -q '^intl$' || docker-php-ext-install intl
 php -m | grep -q '^gettext$' || docker-php-ext-install gettext
 php -m | grep -q '^sockets$' || docker-php-ext-install sockets
-docker-php-ext-enable ds yaml decimal uuid mailparse msgpack amqp
+case $PHP_VERSION in
+  8.6*)
+    docker-php-ext-enable mailparse
+    ;;
+  *)
+    docker-php-ext-enable ds yaml decimal uuid mailparse msgpack amqp
+    ;;
+esac
 
 case $PHP_VERSION in
-  8.5*)
+  8.5*|8.6*)
     echo "Skipping sqlsrv pdo_sqlsrv oauth for PHP $PHP_VERSION"
     ;;
   *)
@@ -268,7 +298,15 @@ case $PHP_VERSION in
 esac
 
 docker-php-ext-install gmp ldap xsl mysqli calendar gd pdo_mysql pdo_pgsql zip bcmath soap exif bz2 pcntl
-docker-php-ext-enable rdkafka apcu
+
+case $PHP_VERSION in
+  8.6*)
+    echo "Skipping rdkafka apcu enable for PHP $PHP_VERSION"
+    ;;
+  *)
+    docker-php-ext-enable rdkafka apcu
+    ;;
+esac
 
 mkdir ~/.ssh/
 ssh-keyscan -t rsa git.drupal.org >> ~/.ssh/known_hosts


### PR DESCRIPTION
php:8.6.0alpha1-alpine does not ship pecl yet, so every pecl-based
extension install/enable now skips for 8.6 (mirroring existing 8.5
workarounds), and wires up 8.6 in the buildx/test CI matrices with the
8.6.0alpha1 alpha tag.